### PR TITLE
Replace magic numbers for Elf ATs with uniform defines

### DIFF
--- a/l4re_itas/server/src/globals.cc
+++ b/l4re_itas/server/src/globals.cc
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <l4/sys/compiler.h>
 #include <l4/crtn/initpriorities.h>
+#include <l4/util/elf.h>
 
 // internal uclibc symbol for ENV
 extern char const **__environ;
@@ -36,7 +37,7 @@ namespace Global
 
     while (*auxp)
       {
-        if (*auxp == 0xf0)
+        if (*auxp == AT_L4_AUX)
           l4re_aux = reinterpret_cast<l4re_aux_t *>(auxp[1]);
         auxp += 2;
       }

--- a/l4util/include/elf.h
+++ b/l4util/include/elf.h
@@ -956,6 +956,7 @@ enum Elf_ATs
 
   AT_L4_AUX      = 0xf0, /**< L4Re AUX section */
   AT_L4_ENV      = 0xf1, /**< L4Re ENV section */
+  AT_L4_KIP      = 0xf2, /**< L4Re KIP section */
 };
 
 /** Auxiliary vector (32-bit). */

--- a/libc/musl/contrib/musl/include/elf.h
+++ b/libc/musl/contrib/musl/include/elf.h
@@ -1067,6 +1067,9 @@ typedef struct {
 #define AT_L3_CACHEGEOMETRY	47
 
 #define AT_MINSIGSTKSZ		51
+#define AT_L4_AUX	0xf0
+#define AT_L4_ENV	0xf1
+#define AT_L4_KIP	0xf2
 
 
 typedef struct {

--- a/libc/musl/contrib/musl/src/env/__libc_start_main.c
+++ b/libc/musl/contrib/musl/src/env/__libc_start_main.c
@@ -39,9 +39,9 @@ void __init_libc(char **envp, char *pn)
           {
                   if (auxv[i]<AUX_CNT) aux[auxv[i]] = auxv[i+1];
 
-                  if (auxv[i] == 0xf1 && &l4re_global_env)
+                  if (auxv[i] == AT_L4_ENV && &l4re_global_env)
                          l4re_global_env = (void *)auxv[i+1];
-                  else if (auxv[i] == 0xf2 && &l4_global_kip)
+                  else if (auxv[i] == AT_L4_KIP && &l4_global_kip)
                          l4_global_kip = (void *)auxv[i+1];
 
           }

--- a/libc/uclibc-ng/contrib/uclibc/include/elf.h
+++ b/libc/uclibc-ng/contrib/uclibc/include/elf.h
@@ -1143,6 +1143,9 @@ typedef struct
 #define AT_L1D_CACHESHAPE	35
 #define AT_L2_CACHESHAPE	36
 #define AT_L3_CACHESHAPE	37
+#define AT_L4_AUX	0xf0
+#define AT_L4_ENV	0xf1
+#define AT_L4_KIP	0xf2
 
 /* Note section contents.  Each entry in the note section begins with
    a header of a fixed form.  */

--- a/libc/uclibc-ng/contrib/uclibc/ldso/ldso/dl-startup.c
+++ b/libc/uclibc-ng/contrib/uclibc/ldso/ldso/dl-startup.c
@@ -185,8 +185,8 @@ DL_START(unsigned long args)
 		if (auxv_entry->a_type < AUX_MAX_AT_ID) {
 			_dl_memcpy(&(_dl_auxvt_tmp[auxv_entry->a_type]), auxv_entry, sizeof(ElfW(auxv_t)));
 		}
-#ifndef L4_ONLY
-		if (auxv_entry->a_type == 0xf1) {
+#ifndef __NOT_FOR_L4__
+		if (auxv_entry->a_type == AT_L4_ENV) {
 			l4re_env = (void*)auxv_entry->a_un.a_val;
 		}
 #endif
@@ -402,7 +402,7 @@ DL_START(unsigned long args)
 #endif
 	__rtld_stack_end = (void *)(argv - 1);
 
-#ifndef __ONLY_FOR_L4__
+#ifndef __NOT_FOR_L4__
 	_dl_setup_malloc(_dl_auxvt_tmp);
 
 	{

--- a/libc/uclibc-ng/contrib/uclibc/libc/misc/elf/dl-support.c
+++ b/libc/uclibc-ng/contrib/uclibc/libc/misc/elf/dl-support.c
@@ -56,9 +56,9 @@ void internal_function _dl_aux_init (ElfW(auxv_t) *av)
          _dl_auxvt[av->a_type] = *av;
 
 #ifndef __NOT_FOR_L4__
-       if (av->a_type == 0xf1 && &l4re_global_env)
+       if (av->a_type == AT_L4_ENV && &l4re_global_env)
          l4re_global_env = (void *)av->a_un.a_val;
-       else if (av->a_type == 0xf2 && &l4_global_kip)
+       else if (av->a_type == AT_L4_KIP && &l4_global_kip)
          l4_global_kip = (void *)av->a_un.a_val;
 #endif
      }

--- a/libloader/include/loader
+++ b/libloader/include/loader
@@ -250,16 +250,16 @@ Loader<App_model_, Dbg_>::launch(App_model *am, Const_dataspace bin,
 
   // L4Re Env Pointer
   stack.push_local_ptr(env);
-  stack.push(l4_umword_t(0xF1));
+  stack.push(l4_umword_t(AT_L4_ENV));
 
   // KIP Pointer
   stack.push(l4_umword_t(am->prog_info()->kip));
-  stack.push(l4_umword_t(0xF2));
+  stack.push(l4_umword_t(AT_L4_KIP));
 
   if (l4aux_ptr)
     {
       stack.push_local_ptr(l4aux_ptr);
-      stack.push(l4_umword_t(0xF0));
+      stack.push(l4_umword_t(AT_L4_AUX));
     }
 
   am->extra_elf_auxv();

--- a/ned/server/src/main.cc
+++ b/ned/server/src/main.cc
@@ -43,7 +43,7 @@ run(int argc, char const *const *argv)
 
   l4re_aux = 0;
 
-  auto *sentinel = reinterpret_cast<char const*>(0xf0);
+  auto *sentinel = reinterpret_cast<char const*>(AT_L4_AUX);
   while (*auxp)
     {
       if (*auxp == sentinel)


### PR DESCRIPTION
This commit
- adds `AT_L4_KIP` to the `Elf_ATs` enum where it was missing
- adds defines for the 3 custom ATs to uclibc's elf.h
- replaces all usages of the magic numbers
- replaces inconsistent `__ONLY_FOR_L4__` and `L4_ONLY` ifndefs

Change-Id: If8c8e3d6e3ffc1566fc3735332b13b52b8d51be3


I recently had a tour through L4Re's userspace startup code, and had minor trouble identifying the matching parts of libloader and uclibc. To be the change I'd like to see, I replaced the magic values of `AT_L4_AUX`, `AT_L4_ENV` and `AT_L4_PIK` with defines at both locations.

Whilst doing so I noticed the `ifndef L4_ONLY` and `ifndef __ONLY_FOR_L4__` directives didn't make much sense - they would be false if `L4_ONLY` or `__ONLY_FOR_L4__` would be set, but the code they are guarding is very explicitly designed for L4Re.

Lastly I didn't find code handling `AT_L4_AUX`, but didn't dare to remove it in case I just didn't find the correct location yet.
